### PR TITLE
removal: lombok generated annotation main class

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/Main.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/Main.java
@@ -7,8 +7,6 @@ import lombok.Generated;
 
 @SpringBootApplication
 public class Main {
-	@Generated
-	public static void main(String[] args) {
-		SpringApplication.run(Main.class, args);
+	public static void main(String[] args) {SpringApplication.run(Main.class, args);
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The Lombok Generated annotation was being applied incorrectly. It was assumed that this could be used to simply exempt a class from the JaCoCo code coverage report. While that effect _does_ happen, it is a misuse of the annotation and doesn't belong there. The annotation is now removed.
<br>

## Related Tickets & Documents

<br>

## Instructions, Screenshots, Recordings

<br>

## Added/Updated Tests?

- [ ] Yes
- [x] No

Comments:

<br>

## Code Coverage Value?

- [x] 80% or higher
- [ ] Below 80%

Comments:

Code coverage value 91%.
<br>

## Any Future Tasks to Perform?

- [x] Yes
- [ ] No

Comments:

Create a simple test for loading the context in the main application class.