### PR TITLE
dependency add'n: spring-boot-starter-validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
 
     </dependencies>
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Instead of handling invalid input errors that are empty using extra code, this dependency can be used to invoke the NotEmpty annotation.

<br>

## Related Tickets & Documents

<br>

## Instructions, Screenshots, Recordings

<br>

## Added/Updated Tests?

- [ ] Yes
- [x] No

Comments:

Will see if tests need adjustment after annotation is added.
<br>

## Code Coverage Value?

- [ ] 80% or higher
- [ ] Below 80%

Comments:

<br>

## Any Future Tasks to Perform?

- [ ] Yes
- [ ] No

Comments: