### PR TITLE
fix: last computationService test

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/ComputationService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/ComputationService.java
@@ -24,7 +24,6 @@ public class ComputationService {
 					double gammaCoefficient = gammaNumerator / gammaDenominator;
 					double newCoefficient = coefficient * gammaCoefficient;
 					double newPower = degree - i - alpha;
-					// Only add terms with non-negative power
 					if (newPower >= 0) {
 						terms.add(new Term(newCoefficient, newPower));
 					}
@@ -35,13 +34,13 @@ public class ComputationService {
 		// Sort terms by the power in descending order
 		terms.sort(Comparator.comparingDouble(Term::power).reversed());
 
-		// Build the result string
 		StringBuilder result = new StringBuilder();
 		for (int i = 0; i < terms.size(); i++) {
 			Term term = terms.get(i);
 			if (i > 0) {
 				if (term.coefficient() > 0) {
 					result.append(" + ");
+					result.append(String.format("%.3f", term.coefficient()));
 				} else {
 					result.append(" - ");
 					result.append(String.format("%.3f", Math.abs(term.coefficient())));

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ComputationServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ComputationServiceTest.java
@@ -16,80 +16,44 @@ public class ComputationServiceTest {
 
     @Test
     public void testDerivativeConstantTerm() {
-        double[] coefficients = {3.0}; // Represents the polynomial 3
+        double[] coefficients = {3.0}; // Represents a constant value of 3.0
         double alpha = 0.5;
-
-        // Print the coefficients and alpha for debugging
-        System.out.println("Testing Caputo Fractional Derivative for Single Term");
-        System.out.println("Coefficients: 3.0");
-        System.out.println("Alpha: " + alpha);
 
         String result = computationService.caputoFractionalDerivative(coefficients, alpha);
         String expected = ""; // Derivative of a constant should be zero
 
-        // Print the result for debugging
-        System.out.println("Result: " + result);
-        System.out.println("Expected: " + expected);
-
         assertEquals(expected, result);
     }
 
-//    @Test
-//    public void testDerivativeNonZeroCoefficients() {
-//        double[] coefficients = {3.0, 2.0, 1.0}; // Represents the polynomial 3x^2 + 2x + 1
-//        double alpha = 0.5;
-//
-//        // Print the coefficients and alpha for debugging
-//        System.out.println("Testing Caputo Fractional Derivative for Non-Zero Coefficients");
-//        System.out.println("Coefficients: 3.0, 2.0, 1.0");
-//        System.out.println("Alpha: " + alpha);
-//
-//        String result = computationService.caputoFractionalDerivative(coefficients, alpha);
-//        String expected = "4.514x^1.500 + 2.257x^0.500"; // Adjusted expected result
-//
-//        // Print the result for debugging
-//        System.out.println("Result: " + result);
-//        System.out.println("Expected: " + expected);
-//
-//        assertEquals(expected, result);
-//    }
+    @Test
+    public void testDerivativeNonZeroCoefficients() {
+        double[] coefficients = {3.0, 2.0, 1.0}; // Represents the polynomial 3x^2 + 2x + 1
+        double alpha = 0.5;
+
+        String result = computationService.caputoFractionalDerivative(coefficients, alpha);
+        String expected = "4.514x^1.500 + 2.257x^0.500";
+
+        assertEquals(expected, result);
+    }
 
     @Test
     public void testDerivativeDifferentAlpha() {
         double[] coefficients = {3.0, 0.0, 1.0}; // Represents the polynomial 3x^2 + 1
         double alpha = 1.5;
 
-        // Print the coefficients and alpha for debugging
-        System.out.println("Testing Caputo Fractional Derivative for Different Alpha");
-        System.out.println("Coefficients: 3.0, 0.0, 1.0");
-        System.out.println("Alpha: " + alpha);
-
         String result = computationService.caputoFractionalDerivative(coefficients, alpha);
-        String expected = "6.770x^0.500"; // Adjusted expected result
-
-        // Print the result for debugging
-        System.out.println("Result: " + result);
-        System.out.println("Expected: " + expected);
+        String expected = "6.770x^0.500";
 
         assertEquals(expected, result);
     }
 
     @Test
     public void testDerivativeZeroCoefficients() {
-        double[] coefficients = {0.0, 0.0, 0.0}; // Represents a zero polynomial
+        double[] coefficients = {0.0, 0.0, 0.0}; // Represents an empty expression
         double alpha = 0.5;
-
-        // Print the coefficients and alpha for debugging
-        System.out.println("Testing Caputo Fractional Derivative for Zero Coefficients");
-        System.out.println("Coefficients: 0.0, 0.0, 0.0");
-        System.out.println("Alpha: " + alpha);
 
         String result = computationService.caputoFractionalDerivative(coefficients, alpha);
         String expected = "";
-
-        // Print the result for debugging
-        System.out.println("Result: " + result);
-        System.out.println("Expected: " + expected);
 
         assertEquals(expected, result);
     }


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Saw that the 2nd term's coefficient was not being applied to the term, resulting in the other test's failure. 
Fixed, all tests green now. Also removed a bunch of debugging lines that are no longer necessary.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%

Code coverage currently at 88%.

<br/>
<br/>