### PR TITLE
dependency add'n: commons-math3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [x] Optimization
- [ ] Documentation Update

## Description

Added the Apache Commons Math3 dependency to upgrade the gamma function's 'double' value type to BigDecimal. This improved noticable roundoff issues in the answers.

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No

Will be updating tests when new classes are added.

<br/>


## Code Coverage Value?
- [ ] 80% or higher
- [ ] Below 80%



<br/>
<br/>