### PR TITLE
comment: skip reformat code on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- @formatter:off -->
 ## What type of PR is this?
 
 - [ ] Bug Fix


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [x] Documentation Update

## Description

Reformat code was messing with some of the empty space in this PR template for adding comments. Now contains a comment so the reformatter ignores it.

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>