### PR TITLE
bug fix: output zero formatting

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeFormattingService.java
@@ -15,12 +15,10 @@ public class CaputoDerivativeFormattingService {
       Term term = terms.get(i);
       BigDecimal coefficient = term.coefficient().setScale(3, RoundingMode.HALF_UP);
 
-      String coefficientString;
-      if (coefficient.stripTrailingZeros().scale() <= 0) {
-        coefficientString = coefficient.stripTrailingZeros().toPlainString();
-      } else {
-        coefficientString = coefficient.toPlainString();
-      }
+      String coefficientString =
+          coefficient.stripTrailingZeros().scale() <= 0
+              ? coefficient.stripTrailingZeros().toPlainString()
+              : coefficient.toPlainString().replaceAll("\\.000$", "");
 
       if (i > 0) {
         if (coefficient.compareTo(BigDecimal.ZERO) > 0) {
@@ -29,7 +27,7 @@ public class CaputoDerivativeFormattingService {
           result.append(" - ");
         }
         if (coefficient.abs().compareTo(BigDecimal.ONE) != 0) {
-          result.append(coefficient.abs().toPlainString());
+          result.append(coefficient.abs().toPlainString().replaceAll("\\.000$", ""));
         }
       } else {
         if (coefficient.compareTo(BigDecimal.ZERO) < 0) {

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeServiceTest.java
@@ -114,6 +114,35 @@ public class CaputoDerivativeServiceTest {
   }
 
   @Test
+  public void testComputeDerivative_WholePositiveCoefficients_IntegerAlpha() {
+    double[] coefficients = {1, 3, -6, 0, 0, 2};
+    double alpha = 1.0;
+
+    try (MockedStatic<MathUtils> utilities = mockStatic(MathUtils.class)) {
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(6)))
+          .thenReturn(new BigDecimal("120.000000000000000"));
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(5)))
+          .thenReturn(new BigDecimal("24.000000000000000"));
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(4)))
+          .thenReturn(new BigDecimal("6.000000000000000"));
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(3)))
+          .thenReturn(new BigDecimal("2.000000000000000"));
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(2)))
+          .thenReturn(new BigDecimal("1.000000000000000"));
+
+      String result = caputoDerivativeService.evaluateExpression(coefficients, alpha);
+      String expected = "5x^4 + 12x^3 - 18x^2";
+
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
   public void testComputeDerivative_ZeroCoefficient() {
     double[] coefficients = {0.0, 2.0, -1.0};
     double alpha = 0.5;


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Noticed that outputs with whole numbers for coefficients were only having zeros stripped in the first term.
(i.e. 5x^2 + 2.000x - 18.000)

This issue is now fixed.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>