### PR TITLE
bug fix: negative exponent wasn't removed

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeFormattingService.java
@@ -13,6 +13,9 @@ public class CaputoDerivativeFormattingService {
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < terms.size(); i++) {
       Term term = terms.get(i);
+      if (term.power().compareTo(BigDecimal.ZERO) < 0) {
+        continue; // Skip terms with negative exponents
+      }
       BigDecimal coefficient = term.coefficient().setScale(3, RoundingMode.HALF_UP);
 
       String coefficientString =


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed an issue where negative exponents in terms other than the last position weren't being omitted. Fixed.

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>