### PR TITLE
enhancement: rieman-liou-deriv output

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleFormattingService.java
@@ -13,27 +13,38 @@ public class RiemannLiouvilleFormattingService {
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < terms.size(); i++) {
       Term term = terms.get(i);
+      BigDecimal coefficient = term.coefficient().setScale(3, RoundingMode.HALF_UP);
+
       if (i > 0) {
-        if (term.coefficient().compareTo(BigDecimal.ZERO) > 0) {
+        if (coefficient.compareTo(BigDecimal.ZERO) > 0) {
           result.append(" + ");
         } else {
           result.append(" - ");
         }
-        result.append(term.coefficient().abs().setScale(3, RoundingMode.HALF_UP));
+        if (coefficient.abs().compareTo(BigDecimal.ONE) != 0) {
+          result.append(coefficient.abs().toPlainString());
+        }
       } else {
-        if (term.coefficient().compareTo(BigDecimal.ZERO) < 0) {
-          result.append("- ");
-          result.append(term.coefficient().abs().setScale(3, RoundingMode.HALF_UP));
+        if (coefficient.compareTo(BigDecimal.ZERO) < 0) {
+          result.append("-");
+          if (coefficient.abs().compareTo(BigDecimal.ONE) != 0) {
+            result.append(coefficient.abs().toPlainString());
+          }
         } else {
-          result.append(term.coefficient().setScale(3, RoundingMode.HALF_UP));
+          if (coefficient.compareTo(BigDecimal.ONE) != 0) {
+            result.append(coefficient.toPlainString());
+          }
         }
       }
 
       // Check if power is zero, and if so, only append the coefficient
       if (term.power().compareTo(BigDecimal.ZERO) != 0) {
-        // Remove the trailing zeros from exponents in output
-        String exponent = term.power().stripTrailingZeros().toPlainString();
-        result.append("x^").append(exponent);
+        result.append("x");
+        if (term.power().compareTo(BigDecimal.ONE) != 0) {
+          // Remove the trailing zeros from exponents in output
+          String exponent = term.power().stripTrailingZeros().toPlainString();
+          result.append("^").append(exponent);
+        }
       }
     }
     return result.toString();

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleDerivativeServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleDerivativeServiceTest.java
@@ -179,12 +179,4 @@ public class RiemannLiouvilleDerivativeServiceTest {
       assertEquals(expected, result);
     }
   }
-  //
-  //  @Configuration
-  //  static class Config {
-  //    @Bean
-  //    public RiemannLiouvilleDerivativeService riemannLiouvilleDerivativeService() {
-  //      return new RiemannLiouvilleDerivativeService();
-  //    }
-  //  }
 }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleDerivativeServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleDerivativeServiceTest.java
@@ -76,7 +76,7 @@ public class RiemannLiouvilleDerivativeServiceTest {
           .thenReturn(new BigDecimal("-3.54490770181"));
 
       String result = riemannLiouvilleDerivativeService.evaluateExpression(coefficients, alpha);
-      String expected = "- 4.515x^1.5 - 2.257x^0.5 - 0.564x^-0.5";
+      String expected = "-4.515x^1.5 - 2.257x^0.5 - 0.564x^-0.5";
 
       assertEquals(expected, result);
     }


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [x] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed up the output of the RiemannLiouvilleDerivativeService output. The first term no longer has a space after the minus sign (i.e. "-4.516" vs. the previous "- 4.516"), and coefficients now properly display using three decimal places. 

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>