### PR TITLE
refactor: method name for consistency

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeComputationService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeComputationService.java
@@ -23,7 +23,7 @@ public class CaputoDerivativeComputationService {
     if (alpha.stripTrailingZeros().scale() <= 0) {
       computeIntegerOrderDerivativeTerms(coefficients, alpha.intValue(), terms, degree);
     } else {
-      computeFractionalOrderTerms(coefficients, alpha, terms, degree);
+      computeFractionalOrderDerivativeTerms(coefficients, alpha, terms, degree);
     }
 
     terms.sort(Comparator.comparing(Term::power).reversed());
@@ -49,7 +49,7 @@ public class CaputoDerivativeComputationService {
     }
   }
 
-  private void computeFractionalOrderTerms(
+  private void computeFractionalOrderDerivativeTerms(
       double[] coefficients, BigDecimal alpha, List<Term> terms, int degree) {
     for (int i = 0; i <= degree; i++) {
       BigDecimal coefficient = BigDecimal.valueOf(coefficients[i]);


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [x] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Changed the method name for computing the fractional terms to include 'derivative' in the name so it's consistent with the other method doing the same thing for integer-order derivatives.

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>