### PR TITLE
update: CaputoDerivative return 0

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeFormattingService.java
@@ -50,6 +50,11 @@ public class CaputoDerivativeFormattingService {
         }
       }
     }
+
+    if (result.isEmpty()) {
+      return "0";
+    }
+
     return result.toString();
   }
 }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/caputo/CaputoDerivativeServiceTest.java
@@ -25,6 +25,8 @@ public class CaputoDerivativeServiceTest {
 
   @Autowired private CaputoDerivativeService caputoDerivativeService;
 
+  @Autowired private CaputoDerivativeFormattingService formattingService;
+
   @Test
   public void testComputeDerivative_SimplePolynomial() {
     double[] coefficients = {3.0, 2.0, 1.0};
@@ -83,7 +85,7 @@ public class CaputoDerivativeServiceTest {
     double alpha = 0.5;
 
     String result = caputoDerivativeService.evaluateExpression(coefficients, alpha);
-    String expected = "";
+    String expected = "0";
 
     assertEquals(expected, result);
   }
@@ -169,7 +171,7 @@ public class CaputoDerivativeServiceTest {
     double alpha = 0.5;
 
     String result = caputoDerivativeService.evaluateExpression(coefficients, alpha);
-    String expected = "";
+    String expected = "0";
 
     assertEquals(expected, result);
   }
@@ -189,6 +191,26 @@ public class CaputoDerivativeServiceTest {
 
       String result = caputoDerivativeService.evaluateExpression(coefficients, alpha);
       String expected = "6.770x^0.5";
+
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  public void testComputeDerivative_NegativeExponentSuccessfulOmit() {
+    double[] coefficients = {1.0, 1.0};
+    double alpha = 1.5;
+
+    try (MockedStatic<MathUtils> utilities = mockStatic(MathUtils.class)) {
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(3)))
+          .thenReturn(new BigDecimal(gamma_3));
+      utilities
+          .when(() -> MathUtils.gamma(BigDecimal.valueOf(1.5)))
+          .thenReturn(new BigDecimal(gamma_1_point_5));
+
+      String result = caputoDerivativeService.evaluateExpression(coefficients, alpha);
+      String expected = "0";
 
       assertEquals(expected, result);
     }


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed an issue where Caputo derivatives were returning an empty string rather than a "0" to indicate to users the derivative was performed.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>