### PR TITLE
bugfix: strip ".000" from final term

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleFormattingService.java
@@ -16,26 +16,25 @@ public class RiemannLiouvilleFormattingService {
       BigDecimal coefficient = term.coefficient().setScale(3, RoundingMode.HALF_UP);
 
       // Check if coefficient has trailing zeros to be stripped
-      String coefficientStr = coefficient.toPlainString();
-      if (coefficientStr.endsWith(".000")) {
-        coefficientStr = coefficientStr.replaceAll("\\.0+$", "");
-      }
+      String coefficientStr = coefficient.stripTrailingZeros().toPlainString();
 
       if (i > 0) {
         if (coefficient.compareTo(BigDecimal.ZERO) > 0) {
           result.append(" + ");
-          result.append(coefficientStr);
         } else {
           result.append(" - ");
-          result.append(coefficient.abs().toPlainString());
+          coefficientStr = coefficient.abs().stripTrailingZeros().toPlainString();
         }
       } else {
         if (coefficient.compareTo(BigDecimal.ZERO) < 0) {
           result.append("-");
-          result.append(coefficient.abs().toPlainString());
-        } else {
-          result.append(coefficientStr);
+          coefficientStr = coefficient.abs().stripTrailingZeros().toPlainString();
         }
+      }
+
+      if (coefficient.abs().compareTo(BigDecimal.ONE) != 0
+          || term.power().compareTo(BigDecimal.ZERO) == 0) {
+        result.append(coefficientStr);
       }
 
       // Check if power is zero, and if so, only append the coefficient
@@ -47,6 +46,9 @@ public class RiemannLiouvilleFormattingService {
           result.append("^").append(exponent);
         }
       }
+    }
+    if (result.isEmpty()) {
+      return "0";
     }
     return result.toString();
   }


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed a bug causing the last term in a Riemann-Liouville fractional derivative to sometimes display "#.000" for a coefficient instead of just "#". 

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>