### PR TITLE
add'n: integration constant for Caputo

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/integration/caputo/CaputoIntegralFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/integration/caputo/CaputoIntegralFormattingService.java
@@ -57,9 +57,14 @@ public class CaputoIntegralFormattingService {
       }
     }
 
-    if (integerAlpha && alphaInt > 1) {
-      appendConstantsOfIntegration(result, alphaInt);
-    } else if (integerAlpha && alphaInt == 1) {
+    if (integerAlpha) {
+      if (alphaInt > 1) {
+        appendConstantsOfIntegration(result, alphaInt);
+      } else if (alphaInt == 1) {
+        if (!result.isEmpty()) result.append(" + ");
+        result.append("C");
+      }
+    } else {
       if (!result.isEmpty()) result.append(" + ");
       result.append("C");
     }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/CaputoIntegrationServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/CaputoIntegrationServiceTest.java
@@ -45,7 +45,7 @@ public class CaputoIntegrationServiceTest {
     double alpha = 0.5;
     String result = caputoIntegrationService.evaluateExpression(coefficients, alpha);
     assertNotNull(result);
-    String expectedResult = "1.662x^2.5 + 2.659x^1.5 + 2.659x^0.5";
+    String expectedResult = "1.662x^2.5 + 2.659x^1.5 + 2.659x^0.5 + C";
     assertEquals(expectedResult, result);
   }
 


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Caputo fractional integration should also consider a constant of integration at the end of a result. This constant of integration can just remain as "C", regardless of the fractional value of α.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>