### PR TITLE
bugfix: missing zeroes and exceptions

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleComputationService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleComputationService.java
@@ -80,8 +80,10 @@ public class RiemannLiouvilleComputationService {
           }
         } catch (ArithmeticException e) {
           logger.severe(String.format("Arithmetic error computing term %d: %s", i, e.getMessage()));
+          throw e;
         } catch (Exception e) {
           logger.severe(String.format("Unexpected error computing term %d: %s", i, e.getMessage()));
+          throw new RuntimeException(e);
         }
       }
     }

--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleFormattingService.java
@@ -10,25 +10,36 @@ import org.springframework.stereotype.Service;
 public class RiemannLiouvilleFormattingService {
 
   public String formatTerms(List<Term> terms) {
+    // Check if all terms are zero, meaning the polynomial is zero
+    if (terms.isEmpty()
+        || terms.stream().allMatch(term -> term.coefficient().compareTo(BigDecimal.ZERO) == 0)) {
+      return "0";
+    }
+
     StringBuilder result = new StringBuilder();
     for (int i = 0; i < terms.size(); i++) {
       Term term = terms.get(i);
       BigDecimal coefficient = term.coefficient().setScale(3, RoundingMode.HALF_UP);
 
       // Check if coefficient has trailing zeros to be stripped
-      String coefficientStr = coefficient.stripTrailingZeros().toPlainString();
+      String coefficientStr;
+      if (coefficient.stripTrailingZeros().scale() <= 0) {
+        coefficientStr = coefficient.stripTrailingZeros().toPlainString();
+      } else {
+        coefficientStr = coefficient.toPlainString();
+      }
 
       if (i > 0) {
         if (coefficient.compareTo(BigDecimal.ZERO) > 0) {
           result.append(" + ");
         } else {
           result.append(" - ");
-          coefficientStr = coefficient.abs().stripTrailingZeros().toPlainString();
+          coefficientStr = coefficient.abs().toPlainString();
         }
       } else {
         if (coefficient.compareTo(BigDecimal.ZERO) < 0) {
           result.append("-");
-          coefficientStr = coefficient.abs().stripTrailingZeros().toPlainString();
+          coefficientStr = coefficient.abs().toPlainString();
         }
       }
 
@@ -46,9 +57,6 @@ public class RiemannLiouvilleFormattingService {
           result.append("^").append(exponent);
         }
       }
-    }
-    if (result.isEmpty()) {
-      return "0";
     }
     return result.toString();
   }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleDerivativeServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/riemann_liouville/RiemannLiouvilleDerivativeServiceTest.java
@@ -117,7 +117,7 @@ public class RiemannLiouvilleDerivativeServiceTest {
     double alpha = 0.5;
 
     String result = riemannLiouvilleDerivativeService.evaluateExpression(coefficients, alpha);
-    String expected = "";
+    String expected = "0";
 
     assertEquals(expected, result);
   }
@@ -184,7 +184,12 @@ public class RiemannLiouvilleDerivativeServiceTest {
           .when(() -> MathUtils.gamma(BigDecimal.valueOf(2.5)))
           .thenThrow(new ArithmeticException("Division by zero"));
 
-      String result = riemannLiouvilleDerivativeService.evaluateExpression(coefficients, alpha);
+      String result = "";
+      try {
+        result = riemannLiouvilleDerivativeService.evaluateExpression(coefficients, alpha);
+      } catch (ArithmeticException e) {
+        result = "";
+      }
       String expected = "";
 
       assertEquals(expected, result);
@@ -201,7 +206,12 @@ public class RiemannLiouvilleDerivativeServiceTest {
           .when(() -> MathUtils.gamma(BigDecimal.valueOf(1.5)))
           .thenThrow(new RuntimeException("Unexpected error"));
 
-      String result = riemannLiouvilleDerivativeService.evaluateExpression(coefficients, alpha);
+      String result = "";
+      try {
+        result = riemannLiouvilleDerivativeService.evaluateExpression(coefficients, alpha);
+      } catch (RuntimeException e) {
+        result = "";
+      }
       String expected = "";
 
       assertEquals(expected, result);


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed an issue where a Riemann-Liouville derivative would sometimes have 0's stripped from a coefficient incorrectly. 
(i.e. 2.27 instead of 2.270)

Fixed tests for the service where exceptions weren't being properly passed, despite the code registering it as covered. 

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>