### PR TITLE
bugfix: added section to skip 0 terms

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/BaseFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/derivation/BaseFormattingService.java
@@ -48,6 +48,10 @@ public abstract class BaseFormattingService {
   private void appendTerm(StringBuilder result, Term term, String coefficientString) {
     BigDecimal coefficient = term.coefficient().setScale(3, RoundingMode.HALF_UP);
 
+    if (coefficient.compareTo(BigDecimal.ZERO) == 0) {
+      return;
+    }
+
     if (!result.isEmpty()) {
       if (coefficient.compareTo(BigDecimal.ZERO) > 0) {
         result.append(" + ");


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixed an issue preventing the base formatting service from inappropriately displaying terms in the output with a coefficient of zero (i.e. 0x). 

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>