### PR TITLE
add'n: test class for logging expressionParser

### DIFF
--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/utils/expressionparser/ExpressionParserLoggingTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/utils/expressionparser/ExpressionParserLoggingTest.java
@@ -1,0 +1,51 @@
+package com.trbaxter.github.fractionalcomputationapi.utils.expressionparser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.trbaxter.github.fractionalcomputationapi.utils.ExpressionParser;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+public class ExpressionParserLoggingTest {
+
+  private ListAppender<ILoggingEvent> listAppender;
+
+  @BeforeEach
+  public void setUp() {
+    Logger logger = (Logger) LoggerFactory.getLogger(ExpressionParser.class);
+    listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+  }
+
+  @Test
+  public void givenNullPolynomial_whenParsed_thenExceptionThrownAndLogged() {
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> ExpressionParser.parse(null));
+    assertEquals("Polynomial expression cannot be null or empty.", exception.getMessage());
+
+    List<ILoggingEvent> logsList = listAppender.list;
+    assertEquals(1, logsList.size());
+    assertEquals("Polynomial expression is null or empty.", logsList.getFirst().getMessage());
+    assertEquals(Level.ERROR, logsList.getFirst().getLevel());
+  }
+
+  @Test
+  public void givenEmptyPolynomial_whenParsed_thenExceptionThrownAndLogged() {
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> ExpressionParser.parse(""));
+    assertEquals("Polynomial expression cannot be null or empty.", exception.getMessage());
+
+    List<ILoggingEvent> logsList = listAppender.list;
+    assertEquals(1, logsList.size());
+    assertEquals("Polynomial expression is null or empty.", logsList.getFirst().getMessage());
+    assertEquals(Level.ERROR, logsList.getFirst().getLevel());
+  }
+}


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [x] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Added a test class specifically to test the logging capability of the ExpressionParser. The need to have this test in its own class came about due to the tests failing when maven verify/install was being used, despite passing when fired individually. Works fine this way.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>