### PR TITLE
refactor: shortened name

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/differentiation/riemann_liouville/RiemannService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/differentiation/riemann_liouville/RiemannService.java
@@ -1,4 +1,4 @@
-package com.trbaxter.github.fractionalcomputationapi.service.derivation.riemann_liouville;
+package com.trbaxter.github.fractionalcomputationapi.service.differentiation.riemann_liouville;
 
 import com.trbaxter.github.fractionalcomputationapi.model.Term;
 import com.trbaxter.github.fractionalcomputationapi.service.FractionalCalculusService;
@@ -9,25 +9,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class RiemannLiouvilleDerivativeService implements FractionalCalculusService {
-  private static final int DEFAULT_PRECISION = 3;
+public class RiemannService implements FractionalCalculusService {
 
-  private final RiemannLiouvilleComputationService computationService;
-  private final RiemannLiouvilleFormattingService formattingService;
+  private final RiemannComputationService computationService;
+  private final RiemannFormattingService formattingService;
 
   @Autowired
-  public RiemannLiouvilleDerivativeService(
-      RiemannLiouvilleComputationService computationService,
-      RiemannLiouvilleFormattingService formattingService) {
+  public RiemannService(
+      RiemannComputationService computationService, RiemannFormattingService formattingService) {
     this.computationService = computationService;
     this.formattingService = formattingService;
   }
 
   @Override
   public String evaluateExpression(String polynomialExpression, double alpha, Integer precision) {
-    int actualPrecision = (precision != null) ? precision : DEFAULT_PRECISION;
     List<Term> terms = ExpressionParser.parse(polynomialExpression);
     List<Term> computedTerms = computationService.computeTerms(terms, BigDecimal.valueOf(alpha));
-    return formattingService.formatTerms(computedTerms, actualPrecision);
+    return formattingService.formatTerms(computedTerms, precision);
   }
 }


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [x] Refactor
- [x] Optimization
- [ ] Documentation Update

## Description

Name of the class was super long, so shortened to just RiemannService. Also removed logic involving a default precision value, as it doesn't apply anymore.

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>