### PR TITLE
refactor: shorten integral URL

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexController.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexController.java
@@ -46,7 +46,7 @@ public class IndexController {
     return processRequest(request, RLService);
   }
 
-  @PostMapping("integral/caputo")
+  @PostMapping("integral")
   public ResponseEntity<Result> computeCaputoIntegral(@Valid @RequestBody ControllerRequest request) {
     return processRequest(request, integrationService);
   }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexControllerTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexControllerTest.java
@@ -93,7 +93,7 @@ public class IndexControllerTest {
             request.getPolynomialExpression(), request.getOrder(), request.getPrecision()))
         .thenReturn("1.805x^2.5 + 1.505x^1.5 + 1.128x^0.5 + C");
 
-    performPostRequest("/fractional-calculus-computation-api/integral/caputo", request)
+    performPostRequest("/fractional-calculus-computation-api/integral", request)
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.expression").value("1.805x^2.5 + 1.505x^1.5 + 1.128x^0.5 + C"));
   }
@@ -158,7 +158,7 @@ public class IndexControllerTest {
             request.getPolynomialExpression(), request.getOrder(), request.getPrecision()))
         .thenThrow(new RuntimeException("Internal Server Error"));
 
-    performPostRequest("/fractional-calculus-computation-api/integral/caputo", request)
+    performPostRequest("/fractional-calculus-computation-api/integral", request)
         .andExpect(status().isInternalServerError())
         .andExpect(content().json("{\"expression\": \"Internal Server Error\"}"));
   }


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [x] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Given that the Caputo and Riemann-Liouville integration methods both produce the same output, there's no reason to list Caputo in the URL. The README already provides the reasoning as to why this is. 

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>