### PR TITLE
sonarcloud: naming consistency bug

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexController.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexController.java
@@ -25,25 +25,27 @@ public class IndexController {
 
   private static final Logger logger = LoggerFactory.getLogger(IndexController.class);
 
-  private final CaputoService caputoDService;
+  private final CaputoService caputoService;
   private final IntegrationService integrationService;
-  private final RiemannService RLService;
+  private final RiemannService riemannService;
 
   @Autowired
-  public IndexController(CaputoService caputoDService, RiemannService RLService, IntegrationService integrationService) {
-    this.caputoDService = caputoDService;
-    this.RLService = RLService;
+  public IndexController(CaputoService caputoService,
+                         RiemannService riemannService,
+                         IntegrationService integrationService) {
+    this.caputoService = caputoService;
+    this.riemannService = riemannService;
     this.integrationService = integrationService;
   }
 
   @PostMapping("derivative/caputo")
   public ResponseEntity<Result> computeCaputoDerivative(@Valid @RequestBody ControllerRequest request) {
-    return processRequest(request, caputoDService);
+    return processRequest(request, caputoService);
   }
 
   @PostMapping("derivative/riemann-liouville")
   public ResponseEntity<Result> computeRiemannLiouvilleDerivative(@Valid @RequestBody ControllerRequest request) {
-    return processRequest(request, RLService);
+    return processRequest(request, riemannService);
   }
 
   @PostMapping("integral")


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Addressing the following bug from SonarCloud: 

Rename this field "RLService" to match the regular expression '^[a-z][a-zA-Z0-9]*$'.
Field names should comply with a naming convention [java:S116](https://sonarcloud.io/organizations/trbaxter/rules?open=java%3AS116&rule_key=java%3AS116)

<br/>


## Added/Updated Tests?
- [ ] Yes
- [x] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>