### PR TITLE
sonarcloud: replace lambda with ref.

### DIFF
--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/model/TermTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/model/TermTest.java
@@ -42,11 +42,19 @@ class TermTest {
   /** Tests the creation of Term instances with null values. */
   @Test
   void testTermRecordNullCoefficient() {
-    assertThrows(NullPointerException.class, () -> new Term(null, new BigDecimal("2.0")));
+    assertThrows(NullPointerException.class, this::createTermWithNullCoefficient);
   }
 
   @Test
   void testTermRecordNullExponent() {
-    assertThrows(NullPointerException.class, () -> new Term(new BigDecimal("3.5"), null));
+    assertThrows(NullPointerException.class, this::createTermWithNullExponent);
+  }
+
+  private void createTermWithNullCoefficient() {
+    new Term(null, new BigDecimal("2.0"));
+  }
+
+  private void createTermWithNullExponent() {
+    new Term(new BigDecimal("3.5"), null);
   }
 }


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [x] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Attempting to resolve the SonarCloud issue a different way by removing the lambda altogether.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>