### PR TITLE
sonarcloud: arithmetic type bug fix

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingService.java
@@ -64,7 +64,9 @@ public class IntegralFormattingService extends BaseFormattingService {
           MathUtils.gamma(BigDecimal.valueOf(alphaInt)), precision, RoundingMode.HALF_UP);
     } else {
       return BigDecimal.ONE.divide(
-          MathUtils.gamma(BigDecimal.valueOf(alphaInt - i)), precision, RoundingMode.HALF_UP);
+          MathUtils.gamma(BigDecimal.valueOf((double) alphaInt - i)),
+          precision,
+          RoundingMode.HALF_UP);
     }
   }
 


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [x] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Arithmetic bug relating to number types detected by SonarCloud. Fixed by casting the alpha integer variable to type double to prevent calculation issues.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>