### PR TITLE
add'n: test for missing coverage

### DIFF
--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingServiceTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class IntegralFormattingServiceTest {
+class IntegralFormattingServiceTest {
 
   @Test
   void testGetZeroPolynomialResult() {

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingServiceTest.java
@@ -1,0 +1,17 @@
+package com.trbaxter.github.fractionalcomputationapi.service.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class IntegralFormattingServiceTest {
+
+  @Test
+  void testGetZeroPolynomialResult() {
+    IntegralFormattingService service = new IntegralFormattingService();
+    String result = service.getZeroPolynomialResult();
+    assertEquals("C", result, "The zero polynomial result should be 'C'");
+  }
+}


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [x] Cleanup
- [ ] Feature
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Added a test specifically for the IntegralFormattingService class to cover missing lines and bring the JaCoCo report up to 100% coverage.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>