### PR TITLE
refactor: removing the caputo portion of test name

### DIFF
--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegrationServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegrationServiceTest.java
@@ -38,7 +38,7 @@ class IntegrationServiceTest {
    */
   @ParameterizedTest
   @MethodSource(
-      "com.trbaxter.github.fractionalcomputationapi.testdata.integral.CaputoIntegrationTestData#polynomialExpressions")
+      "com.trbaxter.github.fractionalcomputationapi.testdata.integral.IntegrationTestData#polynomialExpressions")
   void testCaputoPolynomialExpressions(
       String polynomialExpression, double alpha, Integer precision, String expected) {
     runTestWithMockedMathUtils(

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/testdata/integral/IntegrationTestData.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/testdata/integral/IntegrationTestData.java
@@ -12,9 +12,9 @@ import org.slf4j.LoggerFactory;
  * computations.<br>
  * It includes various combinations of polynomial coefficients and fractional orders.
  */
-public final class CaputoIntegrationTestData {
+public final class IntegrationTestData {
 
-  private static final Logger logger = LoggerFactory.getLogger(CaputoIntegrationTestData.class);
+  private static final Logger logger = LoggerFactory.getLogger(IntegrationTestData.class);
   private static final Map<String, Map<Double, String>> expectedValues = new HashMap<>();
 
   static {
@@ -102,7 +102,6 @@ public final class CaputoIntegrationTestData {
           "-0.500x^2 - x + C",
           "-0.301x^2.5 - 0.752x^1.5 + C"
         });
-    // Add other general cases similarly...
   }
 
   private static void addSpecificExpectedValues() {
@@ -123,7 +122,6 @@ public final class CaputoIntegrationTestData {
           "0.333x^3 + 0.500x^2 + x + C",
           "0.172x^3.5 + 0.301x^2.5 + 0.752x^1.5 + C"
         });
-    // Add other specific cases similarly...
   }
 
   private static void addExpectedValues(String polynomial, double[] alphas, String[] results) {


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [x] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

No need for the "Caputo" portion to be attached to the test name.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>