### PR TITLE
moving class to outside derivative package

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/BaseFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/BaseFormattingService.java
@@ -1,4 +1,4 @@
-package com.trbaxter.github.fractionalcomputationapi.service.differentiation;
+package com.trbaxter.github.fractionalcomputationapi.service;
 
 import com.trbaxter.github.fractionalcomputationapi.model.Term;
 import java.math.BigDecimal;

--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/differentiation/caputo/CaputoFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/differentiation/caputo/CaputoFormattingService.java
@@ -1,7 +1,7 @@
 package com.trbaxter.github.fractionalcomputationapi.service.differentiation.caputo;
 
 import com.trbaxter.github.fractionalcomputationapi.model.Term;
-import com.trbaxter.github.fractionalcomputationapi.service.differentiation.BaseFormattingService;
+import com.trbaxter.github.fractionalcomputationapi.service.BaseFormattingService;
 import java.math.BigDecimal;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/differentiation/riemann_liouville/RiemannFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/differentiation/riemann_liouville/RiemannFormattingService.java
@@ -1,7 +1,7 @@
 package com.trbaxter.github.fractionalcomputationapi.service.differentiation.riemann_liouville;
 
 import com.trbaxter.github.fractionalcomputationapi.model.Term;
-import com.trbaxter.github.fractionalcomputationapi.service.differentiation.BaseFormattingService;
+import com.trbaxter.github.fractionalcomputationapi.service.BaseFormattingService;
 import java.math.BigDecimal;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/integration/IntegralFormattingService.java
@@ -1,7 +1,7 @@
 package com.trbaxter.github.fractionalcomputationapi.service.integration;
 
 import com.trbaxter.github.fractionalcomputationapi.model.Term;
-import com.trbaxter.github.fractionalcomputationapi.service.differentiation.BaseFormattingService;
+import com.trbaxter.github.fractionalcomputationapi.service.BaseFormattingService;
 import com.trbaxter.github.fractionalcomputationapi.utils.MathUtils;
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/test_services/TestFormattingService.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/test_services/TestFormattingService.java
@@ -1,7 +1,7 @@
 package com.trbaxter.github.fractionalcomputationapi.service.test_services;
 
 import com.trbaxter.github.fractionalcomputationapi.model.Term;
-import com.trbaxter.github.fractionalcomputationapi.service.differentiation.BaseFormattingService;
+import com.trbaxter.github.fractionalcomputationapi.service.BaseFormattingService;
 
 public class TestFormattingService extends BaseFormattingService {
 


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [x] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Description

Since the BaseFormattingService is used by both the derivative and integration services, it makes more sense to have it in the root services folder, rather than tucked away in the derivative section. Adjusted the tests and other classes to reflect the change.

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>