### PR TITLE
modularization: indexController request processing

### DIFF
--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexController.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/controller/IndexController.java
@@ -2,12 +2,12 @@ package com.trbaxter.github.fractionalcomputationapi.controller;
 
 import com.trbaxter.github.fractionalcomputationapi.model.ControllerRequest;
 import com.trbaxter.github.fractionalcomputationapi.model.Result;
+import com.trbaxter.github.fractionalcomputationapi.service.ControllerRequestProcessingService;
 import com.trbaxter.github.fractionalcomputationapi.service.differentiation.caputo.CaputoService;
 import com.trbaxter.github.fractionalcomputationapi.service.differentiation.riemann_liouville.RiemannService;
 import com.trbaxter.github.fractionalcomputationapi.service.integration.IntegrationService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -24,14 +24,18 @@ public class IndexController {
   private final CaputoService caputoService;
   private final IntegrationService integrationService;
   private final RiemannService riemannService;
+  private final ControllerRequestProcessingService processingService;
 
   @Autowired
-  public IndexController(CaputoService caputoService,
-                         RiemannService riemannService,
-                         IntegrationService integrationService) {
+  public IndexController(
+      CaputoService caputoService,
+      RiemannService riemannService,
+      IntegrationService integrationService,
+      ControllerRequestProcessingService processingService) {
     this.caputoService = caputoService;
     this.riemannService = riemannService;
     this.integrationService = integrationService;
+    this.processingService = processingService;
   }
 
   /**
@@ -42,7 +46,7 @@ public class IndexController {
    */
   @PostMapping("derivative/caputo")
   public ResponseEntity<Result> computeCaputoDerivative(@Valid @RequestBody ControllerRequest request) {
-    return processRequest(request, caputoService);
+    return processingService.processRequest(request, caputoService);
   }
 
   /**
@@ -53,7 +57,7 @@ public class IndexController {
    */
   @PostMapping("derivative/riemann-liouville")
   public ResponseEntity<Result> computeRiemannLiouvilleDerivative(@Valid @RequestBody ControllerRequest request) {
-    return processRequest(request, riemannService);
+    return processingService.processRequest(request, riemannService);
   }
 
   /**
@@ -64,43 +68,6 @@ public class IndexController {
    */
   @PostMapping("integral")
   public ResponseEntity<Result> computeCaputoIntegral(@Valid @RequestBody ControllerRequest request) {
-    return processRequest(request, integrationService);
-  }
-
-  /**
-   * Processes the request by evaluating the expression using the appropriate service.
-   *
-   * @param request the controller request.
-   * @param service the service to use for evaluation.
-   * @param <T> the type of the service.
-   * @return a ResponseEntity containing the result.
-   */
-  private <T> ResponseEntity<Result> processRequest(ControllerRequest request, T service) {
-    String result = evaluateExpression(
-        service, request.getPolynomialExpression(), request.getOrder(), request.getPrecision());
-    return new ResponseEntity<>(new Result(result), HttpStatus.OK);
-  }
-
-  /**
-   * Evaluates the polynomial expression using the appropriate service.
-   *
-   * @param service the service to use for evaluation.
-   * @param polynomialExpression the polynomial expression to evaluate.
-   * @param order the order of the operation.
-   * @param precision the precision of the result.
-   * @param <T> the type of the service.
-   * @return the result of the evaluation.
-   * @throws IllegalArgumentException if the service type is unknown.
-   */
-  private <T> String evaluateExpression(T service, String polynomialExpression, double order, Integer precision) {
-      return switch (service) {
-          case CaputoService caputoService1 ->
-              caputoService1.evaluateExpression(polynomialExpression, order, precision);
-          case RiemannService riemannService1 ->
-              riemannService1.evaluateExpression(polynomialExpression, order, precision);
-          case IntegrationService integrationService1 ->
-              integrationService1.evaluateExpression(polynomialExpression, order, precision);
-          case null, default -> throw new IllegalArgumentException("Unknown service type");
-      };
+    return processingService.processRequest(request, integrationService);
   }
 }

--- a/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingService.java
+++ b/src/main/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingService.java
@@ -1,0 +1,31 @@
+package com.trbaxter.github.fractionalcomputationapi.service;
+
+import com.trbaxter.github.fractionalcomputationapi.model.ControllerRequest;
+import com.trbaxter.github.fractionalcomputationapi.model.Result;
+import com.trbaxter.github.fractionalcomputationapi.service.differentiation.caputo.CaputoService;
+import com.trbaxter.github.fractionalcomputationapi.service.differentiation.riemann_liouville.RiemannService;
+import com.trbaxter.github.fractionalcomputationapi.service.integration.IntegrationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ControllerRequestProcessingService {
+
+    public String evaluateExpression(Object service, String polynomialExpression, double order, Integer precision) {
+        return switch (service) {
+            case CaputoService caputoService ->
+                caputoService.evaluateExpression(polynomialExpression, order, precision);
+            case RiemannService riemannService ->
+                riemannService.evaluateExpression(polynomialExpression, order, precision);
+            case IntegrationService integrationService ->
+                integrationService.evaluateExpression(polynomialExpression, order, precision);
+            case null, default -> throw new IllegalArgumentException("Unknown service type");
+        };
+    }
+
+    public <T> ResponseEntity<Result> processRequest(ControllerRequest request, T service) {
+        String result = evaluateExpression(service, request.getPolynomialExpression(), request.getOrder(), request.getPrecision());
+        return new ResponseEntity<>(new Result(result), HttpStatus.OK);
+    }
+}

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingServiceTest.java
@@ -79,10 +79,11 @@ class ControllerRequestProcessingServiceTest {
 
   @Test
   void testEvaluateExpressionWithUnknownService() {
+    Object unknownService = new Object(); // Separate the object creation
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> processingService.evaluateExpression(new Object(), "3x^2 + 2x + 1", 0.5, 3));
+            () -> processingService.evaluateExpression(unknownService, "3x^2 + 2x + 1", 0.5, 3));
 
     assertEquals("Unknown service type", exception.getMessage());
   }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingServiceTest.java
@@ -49,7 +49,7 @@ class ControllerRequestProcessingServiceTest {
     String result = processingService.evaluateExpression(caputoService, "3x^2 + 2x + 1", 0.5, 3);
 
     assertEquals("result", result);
-    verify(caputoService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+    verify(caputoService, times(1)).evaluateExpression("3x^2 + 2x + 1", 0.5, 3);
   }
 
   @Test
@@ -61,7 +61,7 @@ class ControllerRequestProcessingServiceTest {
     String result = processingService.evaluateExpression(riemannService, "3x^2 + 2x + 1", 0.5, 3);
 
     assertEquals("result", result);
-    verify(riemannService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+    verify(riemannService, times(1)).evaluateExpression("3x^2 + 2x + 1", 0.5, 3);
   }
 
   @Test
@@ -74,7 +74,7 @@ class ControllerRequestProcessingServiceTest {
         processingService.evaluateExpression(integrationService, "3x^2 + 2x + 1", 0.5, 3);
 
     assertEquals("result", result);
-    verify(integrationService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+    verify(integrationService, times(1)).evaluateExpression("3x^2 + 2x + 1", 0.5, 3);
   }
 
   @Test
@@ -96,7 +96,7 @@ class ControllerRequestProcessingServiceTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals("result", Objects.requireNonNull(response.getBody()).expression());
-    verify(caputoService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+    verify(caputoService, times(1)).evaluateExpression("3x^2 + 2x + 1", 0.5, 3);
   }
 
   @Test
@@ -109,7 +109,7 @@ class ControllerRequestProcessingServiceTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals("result", Objects.requireNonNull(response.getBody()).expression());
-    verify(riemannService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+    verify(riemannService, times(1)).evaluateExpression("3x^2 + 2x + 1", 0.5, 3);
   }
 
   @Test
@@ -122,6 +122,6 @@ class ControllerRequestProcessingServiceTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals("result", Objects.requireNonNull(response.getBody()).expression());
-    verify(integrationService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+    verify(integrationService, times(1)).evaluateExpression("3x^2 + 2x + 1", 0.5, 3);
   }
 }

--- a/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingServiceTest.java
+++ b/src/test/java/com/trbaxter/github/fractionalcomputationapi/service/ControllerRequestProcessingServiceTest.java
@@ -1,0 +1,127 @@
+package com.trbaxter.github.fractionalcomputationapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.trbaxter.github.fractionalcomputationapi.model.ControllerRequest;
+import com.trbaxter.github.fractionalcomputationapi.model.Result;
+import com.trbaxter.github.fractionalcomputationapi.service.differentiation.caputo.CaputoService;
+import com.trbaxter.github.fractionalcomputationapi.service.differentiation.riemann_liouville.RiemannService;
+import com.trbaxter.github.fractionalcomputationapi.service.integration.IntegrationService;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class ControllerRequestProcessingServiceTest {
+
+  @Mock private CaputoService caputoService;
+
+  @Mock private RiemannService riemannService;
+
+  @Mock private IntegrationService integrationService;
+
+  @InjectMocks private ControllerRequestProcessingService processingService;
+
+  private ControllerRequest request;
+
+  @BeforeEach
+  void setUp() {
+    request = new ControllerRequest();
+    request.setPolynomialExpression("3x^2 + 2x + 1");
+    request.setOrder(0.5);
+    request.setPrecision(3);
+  }
+
+  @Test
+  void testEvaluateExpressionWithCaputoService() {
+    when(caputoService.evaluateExpression(any(String.class), any(double.class), any(Integer.class)))
+        .thenReturn("result");
+
+    String result = processingService.evaluateExpression(caputoService, "3x^2 + 2x + 1", 0.5, 3);
+
+    assertEquals("result", result);
+    verify(caputoService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+  }
+
+  @Test
+  void testEvaluateExpressionWithRiemannService() {
+    when(riemannService.evaluateExpression(
+            any(String.class), any(double.class), any(Integer.class)))
+        .thenReturn("result");
+
+    String result = processingService.evaluateExpression(riemannService, "3x^2 + 2x + 1", 0.5, 3);
+
+    assertEquals("result", result);
+    verify(riemannService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+  }
+
+  @Test
+  void testEvaluateExpressionWithIntegrationService() {
+    when(integrationService.evaluateExpression(
+            any(String.class), any(double.class), any(Integer.class)))
+        .thenReturn("result");
+
+    String result =
+        processingService.evaluateExpression(integrationService, "3x^2 + 2x + 1", 0.5, 3);
+
+    assertEquals("result", result);
+    verify(integrationService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+  }
+
+  @Test
+  void testEvaluateExpressionWithUnknownService() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> processingService.evaluateExpression(new Object(), "3x^2 + 2x + 1", 0.5, 3));
+
+    assertEquals("Unknown service type", exception.getMessage());
+  }
+
+  @Test
+  void testProcessRequestWithCaputoService() {
+    when(caputoService.evaluateExpression(any(String.class), any(double.class), any(Integer.class)))
+        .thenReturn("result");
+
+    ResponseEntity<Result> response = processingService.processRequest(request, caputoService);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("result", Objects.requireNonNull(response.getBody()).expression());
+    verify(caputoService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+  }
+
+  @Test
+  void testProcessRequestWithRiemannService() {
+    when(riemannService.evaluateExpression(
+            any(String.class), any(double.class), any(Integer.class)))
+        .thenReturn("result");
+
+    ResponseEntity<Result> response = processingService.processRequest(request, riemannService);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("result", Objects.requireNonNull(response.getBody()).expression());
+    verify(riemannService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+  }
+
+  @Test
+  void testProcessRequestWithIntegrationService() {
+    when(integrationService.evaluateExpression(
+            any(String.class), any(double.class), any(Integer.class)))
+        .thenReturn("result");
+
+    ResponseEntity<Result> response = processingService.processRequest(request, integrationService);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("result", Objects.requireNonNull(response.getBody()).expression());
+    verify(integrationService, times(1)).evaluateExpression(eq("3x^2 + 2x + 1"), eq(0.5), eq(3));
+  }
+}


### PR DESCRIPTION
<!-- @formatter:off -->
## What type of PR is this?

- [ ] Bug Fix
- [ ] Cleanup
- [ ] Feature
- [ ] Refactor
- [x] Optimization
- [ ] Documentation Update

## Description

IndexController should only have the single responsibility of handling request mapping. The processing logic of those requests should be handled in a new class, `ControllerRequestProcessingService`. This way, the controller only has to worry about HTTP requests and nothing else. 

<br/>


## Added/Updated Tests?
- [x] Yes
- [ ] No



<br/>


## Code Coverage Value?
- [x] 80% or higher
- [ ] Below 80%



<br/>
<br/>